### PR TITLE
Improve Parameterizable structs code generation

### DIFF
--- a/Sources/Discovery/Discovery.swift
+++ b/Sources/Discovery/Discovery.swift
@@ -34,6 +34,18 @@ public let License = """
 // NOTE: This file is automatically-generated!
 """
 
+// From https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413
+let swiftKeywords: Set = [
+  // Keywords used in declarations
+  "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout", "internal", "let", "open", "operator", "private", "protocol", "public", "rethrows", "static", "struct", "subscript", "typealias", "var",
+  // Keywords used in statements
+  "break", "case", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if", "in", "repeat", "return", "switch", "where", "while",
+  // Keywords used in expressions and types
+  "as", "Any", "catch", "false", "is", "nil", "super", "self", "Self", "throw", "throws", "true", "try",
+  // Keywords reserved in particular contexts
+  "associativity", "convenience", "dynamic", "didSet", "final", "get", "infix", "indirect", "lazy", "left", "mutating", "none", "nonmutating", "optional", "override", "postfix", "precedence", "prefix", "Protocol", "required", "right", "set", "Type", "unowned", "weak", "willSet"
+]
+
 extension String {
   public func capitalized() -> String {
     return prefix(1).capitalized + dropFirst()
@@ -54,7 +66,7 @@ extension String {
   }
   
   public func escaped() -> String {
-    if self == "protocol" { // add other reserved words as needed
+    if swiftKeywords.contains(self) {
       return "`" + self + "`"
     } else {
       return self

--- a/Sources/google-api-swift-generator/main.swift
+++ b/Sources/google-api-swift-generator/main.swift
@@ -15,13 +15,13 @@
 import Foundation
 import Discovery
 
-func createStructInitLines(baseIndent: Int, parameters: [String: Schema]) -> String {
+func createStructInitLines(baseIndent: Int, parameters: [(key: String, value: Schema)]) -> String {
   var currentIndent = baseIndent
   var initDeclaration = String(repeating: " ", count: currentIndent) + "public init ("
-  let inputSignature = parameters.sorted(by: { $0.key < $1.key }).map { "`\($0.key)`: \($0.value.Type())?" }.joined(separator: ", ")
+  let inputSignature = parameters.map({ "`\($0.key)`: \($0.value.Type())" + ($0.value.required ?? false ? "" : "? = nil") }).joined(separator: ", ")
   initDeclaration.addLine(inputSignature + ") {")
   currentIndent += 2
-  for p in parameters.sorted(by: { $0.key < $1.key }) {
+  for p in parameters {
     initDeclaration.addLine(indent: currentIndent, "self.`\(p.key)` = `\(p.key)`")
   }
   currentIndent -= 2
@@ -34,17 +34,18 @@ extension Discovery.Method {
   func ParametersTypeDeclaration(resource : String, method : String) -> String {
     var s = ""
     s.addLine()
-    if let parameters = parameters {
+    if let parameters = parameters?.sorted(by: { $0.key < $1.key }) {
       s.addLine(indent:2, "public struct " + ParametersTypeName(resource:resource, method:method) + " : Parameterizable {")
       let initializer = createStructInitLines(baseIndent: 4, parameters: parameters)
       s.addTextWithoutLinebreak(initializer)
       
-      for p in parameters.sorted(by:  { $0.key < $1.key }) {
-        s.addLine(indent:4, "public var " + p.key + " : " + p.value.Type() + "?")
+      for p in parameters {
+        let optional = !(p.value.required ?? false)
+        s.addLine(indent:4, "public let " + p.key + " : " + p.value.Type() + (optional ? "?" : ""))
       }
       s.addLine(indent:4, "public func queryParameters() -> [String] {")
       s.addLine(indent:6, "return [" +
-        parameters.sorted(by: { $0.key < $1.key })
+        parameters
           .filter { if let location = $0.value.location { return location == "query" } else {return false}}
           .map { return "\"" + $0.key + "\"" }
           .joined(separator: ",")
@@ -52,7 +53,7 @@ extension Discovery.Method {
       s.addLine(indent:4, "}")
       s.addLine(indent:4, "public func pathParameters() -> [String] {")
       s.addLine(indent:6, "return [" +
-        parameters.sorted(by: { $0.key < $1.key })
+        parameters
           .filter { if let location = $0.value.location { return location == "path" } else {return false}}
           .map { return "\"" + $0.key + "\"" }
           .joined(separator: ",")
@@ -138,11 +139,12 @@ extension Discovery.Service {
       case "object":
         s.addLine()
         s.addLine(indent:2, "public struct \(schema.key) : Codable {")
-        if let properties = schema.value.properties {
+        if let properties = schema.value.properties?.sorted(by: { $0.key < $1.key }) {
           let initializer = createStructInitLines(baseIndent: 4, parameters: properties)
           s.addTextWithoutLinebreak(initializer)
-          for p in properties.sorted(by: { $0.key < $1.key }) {
-            s.addLine(indent:4, "public var `\(p.key)` : \(p.value.Type())?")
+          for p in properties {
+            let optional = !(p.value.required ?? false)
+            s.addLine(indent:4, "public let `\(p.key)` : \(p.value.Type())\(optional ? "?" : "")")
           }
         }
         s.addLine(indent:2, "}")
@@ -155,11 +157,12 @@ extension Discovery.Service {
               s.addLine(indent:2, "public typealias \(schema.key) = [\(schema.key)Item]")
               s.addLine()
               s.addLine(indent:2, "public struct \(schema.key)Item : Codable {")
-              if let properties = itemsSchema.properties {
+              if let properties = itemsSchema.properties?.sorted(by: { $0.key < $1.key }) {
                 let initializer = createStructInitLines(baseIndent: 4, parameters: properties)
                 s.addTextWithoutLinebreak(initializer)
-                for p in properties.sorted(by: { $0.key < $1.key }) {
-                  s.addLine(indent:4, "public var `\(p.key)` : \(p.value.Type())?")
+                for p in properties {
+                  let optional = !(p.value.required ?? false)
+                  s.addLine(indent:4, "public let \(p.key) : \(p.value.Type())\(optional ? "?" : "")")
                 }
               }
               s.addLine("}")

--- a/Sources/google-api-swift-generator/main.swift
+++ b/Sources/google-api-swift-generator/main.swift
@@ -18,11 +18,11 @@ import Discovery
 func createStructInitLines(baseIndent: Int, parameters: [(key: String, value: Schema)]) -> String {
   var currentIndent = baseIndent
   var initDeclaration = String(repeating: " ", count: currentIndent) + "public init ("
-  let inputSignature = parameters.map({ "`\($0.key)`: \($0.value.Type())" + ($0.value.required ?? false ? "" : "? = nil") }).joined(separator: ", ")
+  let inputSignature = parameters.map({ "\($0.key): \($0.value.Type())" + ($0.value.required ?? false ? "" : "? = nil") }).joined(separator: ", ")
   initDeclaration.addLine(inputSignature + ") {")
   currentIndent += 2
   for p in parameters {
-    initDeclaration.addLine(indent: currentIndent, "self.`\(p.key)` = `\(p.key)`")
+    initDeclaration.addLine(indent: currentIndent, "self.\(p.key.escaped()) = \(p.key.escaped())")
   }
   currentIndent -= 2
   initDeclaration.addLine(indent: currentIndent, "}")
@@ -144,7 +144,7 @@ extension Discovery.Service {
           s.addTextWithoutLinebreak(initializer)
           for p in properties {
             let optional = !(p.value.required ?? false)
-            s.addLine(indent:4, "public let `\(p.key)` : \(p.value.Type())\(optional ? "?" : "")")
+            s.addLine(indent:4, "public let \(p.key.escaped()) : \(p.value.Type())\(optional ? "?" : "")")
           }
         }
         s.addLine(indent:2, "}")
@@ -162,7 +162,7 @@ extension Discovery.Service {
                 s.addTextWithoutLinebreak(initializer)
                 for p in properties {
                   let optional = !(p.value.required ?? false)
-                  s.addLine(indent:4, "public let \(p.key) : \(p.value.Type())\(optional ? "?" : "")")
+                  s.addLine(indent:4, "public let \(p.key.escaped()) : \(p.value.Type())\(optional ? "?" : "")")
                 }
               }
               s.addLine("}")

--- a/Sources/google-api-swift-generator/main.swift
+++ b/Sources/google-api-swift-generator/main.swift
@@ -15,14 +15,23 @@
 import Foundation
 import Discovery
 
+private func safeParameter(_ parameter: (key: String, value: Schema)) -> String {
+    if parameter.key == "self" && parameter.value.type == "boolean" {
+        return "isSelf"
+    } else if parameter.key == "self" {
+        return "self_"
+    }
+    return parameter.key
+}
+
 func createStructInitLines(baseIndent: Int, parameters: [(key: String, value: Schema)]) -> String {
   var currentIndent = baseIndent
   var initDeclaration = String(repeating: " ", count: currentIndent) + "public init ("
-  let inputSignature = parameters.map({ "\($0.key): \($0.value.Type())" + ($0.value.required ?? false ? "" : "? = nil") }).joined(separator: ", ")
+  let inputSignature = parameters.map({ "\(safeParameter($0)): \($0.value.Type())" + ($0.value.required ?? false ? "" : "? = nil") }).joined(separator: ", ")
   initDeclaration.addLine(inputSignature + ") {")
   currentIndent += 2
   for p in parameters {
-    initDeclaration.addLine(indent: currentIndent, "self.\(p.key.escaped()) = \(p.key.escaped())")
+    initDeclaration.addLine(indent: currentIndent, "self.\(p.key.escaped()) = \(safeParameter(p).escaped())")
   }
   currentIndent -= 2
   initDeclaration.addLine(indent: currentIndent, "}")


### PR DESCRIPTION
Following up on #8

* Use let instead of var for properties
* Make required properties non optional
* Improve the initializer with default nil values when a parameterizable struct has optional properties
* Improve swift keywords escaping by only escaping properties when necessary

Example of this improvement with the Calendar API.

Before this pull request:

```swift
public struct EventsImportParameters : Parameterizable {
  public init (`calendarId`: String?, `conferenceDataVersion`: Int?, `supportsAttachments`: Bool?) {
    self.`calendarId` = `calendarId`
    self.`conferenceDataVersion` = `conferenceDataVersion`
    self.`supportsAttachments` = `supportsAttachments`
  }
  public var calendarId : String?
  public var conferenceDataVersion : Int?
  public var supportsAttachments : Bool?
  public func queryParameters() -> [String] {
    return ["conferenceDataVersion","supportsAttachments"]
  }
  public func pathParameters() -> [String] {
    return ["calendarId"]
  }
}
```

After this pull request:

```swift
public struct EventsImportParameters : Parameterizable {
  public init (calendarId: String, conferenceDataVersion: Int? = nil, supportsAttachments: Bool? = nil) {
    self.calendarId = calendarId
    self.conferenceDataVersion = conferenceDataVersion
    self.supportsAttachments = supportsAttachments
  }
  public let calendarId : String
  public let conferenceDataVersion : Int?
  public let supportsAttachments : Bool?
  public func queryParameters() -> [String] {
    return ["conferenceDataVersion","supportsAttachments"]
  }
  public func pathParameters() -> [String] {
    return ["calendarId"]
  }
}
```

* The `calendarId` property changes from `String?` to `String`.
* The `conferenceDataVersion` and `supportsAttachments` properties have default nil values in the initializer, allowing for more flexible initialization of the struct.
* Properties which are not swift keywords are not escaped with backticks.