### PR TITLE
Improve error handling by using Result<Z, Error> instead of (Z?, Error?)

### DIFF
--- a/Sources/GoogleAPIRuntime/Service.swift
+++ b/Sources/GoogleAPIRuntime/Service.swift
@@ -147,9 +147,9 @@ open class Service {
   public func perform<Z:Decodable>(
     method : String,
     path : String,
-    completion : @escaping(Result<Z, Error>) -> ()) throws {
+    completion : @escaping(Result<Z, Error>) -> ()) {
     let postData : Data? = nil
-    try connection.performRequest(
+    connection.performRequest(
       method:method,
       urlString:base + path,
       parameters: [:],
@@ -162,15 +162,19 @@ open class Service {
     method : String,
     path : String,
     request : X,
-    completion : @escaping(Result<Z, Error>) -> ()) throws {
-    let encoder = JSONEncoder()
-    let postData = try encoder.encode(request)
-    try connection.performRequest(
-      method:method,
-      urlString:base + path,
-      parameters: [:],
-      body:postData) {(data, response, error) in
-        self.handleResponse(data, response, error, completion)
+    completion : @escaping(Result<Z, Error>) -> ()) {
+    do {
+      let encoder = JSONEncoder()
+      let postData = try encoder.encode(request)
+      connection.performRequest(
+        method:method,
+        urlString:base + path,
+        parameters: [:],
+        body:postData) {(data, response, error) in
+          self.handleResponse(data, response, error, completion)
+      }
+    } catch let error {
+      completion(.failure(error))
     }
   }
   
@@ -178,14 +182,19 @@ open class Service {
     method : String,
     path : String,
     parameters : Y,
-    completion : @escaping(Result<Z, Error>) -> ()) throws {
-    let postData : Data? = nil
-    try connection.performRequest(
-      method:method,
-      urlString:base + parameters.path(pattern:path),
-      parameters: parameters.query(),
-      body:postData) {(data, response, error) in
-        self.handleResponse(data, response, error, completion)
+    completion : @escaping(Result<Z, Error>) -> ()) {
+    do {
+      let postData : Data? = nil
+      let path = try parameters.path(pattern:path)
+      connection.performRequest(
+        method:method,
+        urlString:base + path,
+        parameters: parameters.query(),
+        body:postData) {(data, response, error) in
+          self.handleResponse(data, response, error, completion)
+      }
+    } catch let error {
+      completion(.failure(error))
     }
   }
   
@@ -194,15 +203,20 @@ open class Service {
     path : String,
     request : X,
     parameters : Y,
-    completion : @escaping(Result<Z, Error>) -> ()) throws {
-    let encoder = JSONEncoder()
-    let postData = try encoder.encode(request)
-    try connection.performRequest(
-      method:method,
-      urlString:base + parameters.path(pattern:path),
-      parameters: parameters.query(),
-      body:postData) {(data, response, error) in
-        self.handleResponse(data, response, error, completion)
+    completion : @escaping(Result<Z, Error>) -> ()) {
+    do {
+      let encoder = JSONEncoder()
+      let postData = try encoder.encode(request)
+      let path = try parameters.path(pattern:path)
+      connection.performRequest(
+        method:method,
+        urlString:base + path,
+        parameters: parameters.query(),
+        body:postData) {(data, response, error) in
+          self.handleResponse(data, response, error, completion)
+      }
+    } catch let error {
+      completion(.failure(error))
     }
   }
   
@@ -217,9 +231,9 @@ open class Service {
   public func perform(
     method : String,
     path : String,
-    completion : @escaping(Error?) -> ()) throws {
+    completion : @escaping(Error?) -> ()) {
     let postData : Data? = nil
-    try connection.performRequest(
+    connection.performRequest(
       method:method,
       urlString:base + path,
       parameters: [:],
@@ -232,15 +246,19 @@ open class Service {
     method : String,
     path : String,
     request : X,
-    completion : @escaping(Error?) -> ()) throws {
-    let encoder = JSONEncoder()
-    let postData = try encoder.encode(request)
-    try connection.performRequest(
-      method:method,
-      urlString:base + path,
-      parameters: [:],
-      body:postData) {(data, response, error) in
-        self.handleResponse(data, response, error, completion)
+    completion : @escaping(Error?) -> ()) {
+    do {
+      let encoder = JSONEncoder()
+      let postData = try encoder.encode(request)
+      connection.performRequest(
+        method:method,
+        urlString:base + path,
+        parameters: [:],
+        body:postData) {(data, response, error) in
+          self.handleResponse(data, response, error, completion)
+      }
+    } catch let error {
+      completion(error)
     }
   }
   
@@ -248,14 +266,19 @@ open class Service {
     method : String,
     path : String,
     parameters : Y,
-    completion : @escaping(Error?) -> ()) throws {
-    let postData : Data? = nil
-    try connection.performRequest(
-      method:method,
-      urlString:base + parameters.path(pattern:path),
-      parameters: parameters.query(),
-      body:postData) {(data, response, error) in
-        self.handleResponse(data, response, error, completion)
+    completion : @escaping(Error?) -> ()) {
+    do {
+      let postData : Data? = nil
+      let path = try parameters.path(pattern:path)
+      connection.performRequest(
+        method:method,
+        urlString:base + path,
+        parameters: parameters.query(),
+        body:postData) {(data, response, error) in
+          self.handleResponse(data, response, error, completion)
+      }
+    } catch let error {
+      completion(error)
     }
   }
 }

--- a/Sources/GoogleAPIRuntime/Service.swift
+++ b/Sources/GoogleAPIRuntime/Service.swift
@@ -15,9 +15,11 @@
 import Foundation
 import OAuth2
 
-enum GoogleAPIRuntimeError: Error {
+public enum GoogleAPIRuntimeError: Error {
+  case apiError(code: Int, message: String)
+  case internalError
   case missingPathParameter(String)
-  case invalidResponseFromServer
+  case undecodableApiResponse
 }
 
 public protocol Parameterizable {
@@ -25,6 +27,15 @@ public protocol Parameterizable {
   func pathParameters() -> [String]
   func query() -> [String:String]
   func path(pattern: String) throws -> String
+}
+
+public struct ApiError: Decodable {
+  public let code: Int
+  public let message: String
+}
+
+public struct ApiRootError: Decodable {
+  public let error: ApiError
 }
 
 extension Parameterizable {
@@ -87,34 +98,56 @@ open class Service {
     _ data : Data?,
     _ response : URLResponse?,
     _ error : Error?,
-    _ completion : @escaping(Z?, Error?) -> ()) {
-    if let data = data {
-      print(String(data:data, encoding:.utf8)!)
-      let decoder = JSONDecoder()
-      do {
-        let json = try? JSONSerialization.jsonObject(with: data, options: [])
-        if let json = json as? [String:Any] {
-          // remove the "data" wrapper that is used with some APIs (e.g. translate)
-          if let payload = json["data"] {
-            let payloadData = try JSONSerialization.data(withJSONObject:payload)
-            completion(try decoder.decode(Z.self, from: payloadData), nil)
-          } else {
-            completion(try decoder.decode(Z.self, from: data), nil)
-          }
-        }
-      } catch {
-        print(String(data:data, encoding:.utf8)!)
-        completion(nil, error)
+    _ completion : @escaping(Result<Z, Error>) -> ()) {
+    guard let data = data, let response = response as? HTTPURLResponse else {
+      if let error = error {
+        completion(.failure(error))
+      } else {
+        completion(.failure(GoogleAPIRuntimeError.internalError))
       }
+      return
+    }
+    if response.statusCode < 400 {
+      handleResponseSuccess(data: data, completion: completion)
     } else {
-      completion(nil, GoogleAPIRuntimeError.invalidResponseFromServer)
+      handleResponseError(data: data, completion: completion)
+    }
+  }
+  
+  func handleResponseSuccess<Z:Decodable>(data: Data, completion: @escaping(Result<Z, Error>) -> ()) {
+    do {
+      let decoder = JSONDecoder()
+      completion(.success(try decoder.decode(Z.self, from: data)))
+    } catch {
+      do {
+        // try again with the actual payload inside "data" wrapper that is used with some APIs (e.g. translate)
+        let decoder = JSONDecoder()
+        let payload = try decoder.decode([String: Z].self, from: data)
+        if let response = payload["data"] {
+          completion(.success(response))
+        } else {
+          completion(.failure(GoogleAPIRuntimeError.undecodableApiResponse))
+        }
+      } catch let decodingError {
+        completion(.failure(decodingError))
+      }
+    }
+  }
+  
+  func handleResponseError<Z:Decodable>(data: Data, completion: @escaping(Result<Z, Error>) -> ()) {
+    do {
+      let decoder = JSONDecoder()
+      let error = try decoder.decode(ApiRootError.self, from: data).error
+      completion(.failure(GoogleAPIRuntimeError.apiError(code: error.code, message: error.message)))
+    } catch let decodingError {
+      completion(.failure(decodingError))
     }
   }
   
   public func perform<Z:Decodable>(
     method : String,
     path : String,
-    completion : @escaping(Z?, Error?) -> ()) throws {
+    completion : @escaping(Result<Z, Error>) -> ()) throws {
     let postData : Data? = nil
     try connection.performRequest(
       method:method,
@@ -129,7 +162,7 @@ open class Service {
     method : String,
     path : String,
     request : X,
-    completion : @escaping(Z?, Error?) -> ()) throws {
+    completion : @escaping(Result<Z, Error>) -> ()) throws {
     let encoder = JSONEncoder()
     let postData = try encoder.encode(request)
     try connection.performRequest(
@@ -145,7 +178,7 @@ open class Service {
     method : String,
     path : String,
     parameters : Y,
-    completion : @escaping(Z?, Error?) -> ()) throws {
+    completion : @escaping(Result<Z, Error>) -> ()) throws {
     let postData : Data? = nil
     try connection.performRequest(
       method:method,
@@ -161,7 +194,7 @@ open class Service {
     path : String,
     request : X,
     parameters : Y,
-    completion : @escaping(Z?, Error?) -> ()) throws {
+    completion : @escaping(Result<Z, Error>) -> ()) throws {
     let encoder = JSONEncoder()
     let postData = try encoder.encode(request)
     try connection.performRequest(

--- a/Sources/google-api-swift-generator/main.swift
+++ b/Sources/google-api-swift-generator/main.swift
@@ -82,7 +82,7 @@ extension Discovery.Resource {
           s.addLine(indent:4, "parameters: \(m.value.ParametersTypeName(resource:name, method:m.key)),")
         }
         if m.value.HasResponse() {
-          s.addLine(indent:4, "completion: @escaping (\(m.value.ResponseTypeName())?, Error?) -> ()) throws {")
+          s.addLine(indent:4, "completion: @escaping (Result<\(m.value.ResponseTypeName()), Error>) -> ()) throws {")
         } else {
           s.addLine(indent:4, "completion: @escaping (Error?) -> ()) throws {")
         }

--- a/Sources/google-api-swift-generator/main.swift
+++ b/Sources/google-api-swift-generator/main.swift
@@ -82,11 +82,11 @@ extension Discovery.Resource {
           s.addLine(indent:4, "parameters: \(m.value.ParametersTypeName(resource:name, method:m.key)),")
         }
         if m.value.HasResponse() {
-          s.addLine(indent:4, "completion: @escaping (Result<\(m.value.ResponseTypeName()), Error>) -> ()) throws {")
+          s.addLine(indent:4, "completion: @escaping (Result<\(m.value.ResponseTypeName()), Swift.Error>) -> ()) {")
         } else {
-          s.addLine(indent:4, "completion: @escaping (Error?) -> ()) throws {")
+          s.addLine(indent:4, "completion: @escaping (Swift.Error?) -> ()) {")
         }
-        s.addLine(indent:6, "try perform(")
+        s.addLine(indent:6, "perform(")
         s.addLine(indent:8, "method: \"\(m.value.httpMethod!)\",")
         var path = ""
         if m.value.path != nil {


### PR DESCRIPTION
* Also properly decode errors when HTTP status code is greater or equal to 400
* Make all `Service.perfom()` functions  non throwing and return the error through the completion handler if applicable instead