### PR TITLE
Interactive API generation when no service document is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,48 @@ calls from any platform with Swift support should be possible.
 
 ## Usage
 
-API clients are be produced by running the generator with Discovery
-Documents downloaded from the Discovery Service. 
-Running the following writes a client to standard output:
+Running `google-api-swift-generator` will list all available Google APIs and generate a Swift client file in your current directory.
 
 ```sh
-google-api-swift-generator <discovery-document-filename>
+./google-api-swift-generator
+  1) Abusive Experience Report API
+  2) Accelerated Mobile Pages (AMP) URL API
+  3) Access Approval API
+  4) Access Context Manager API
+  5) Ad Exchange Buyer API
+  6) Ad Exchange Buyer API II
+  7) Ad Experience Report API
+  8) Admin Reports API
+  9) AdSense Management API
+ 10) AdSense Host API
+ 11) G Suite Alert Center API
+ 12) Google Analytics API
+[...]
+165) Web Security Scanner API
+166) YouTube Data API
+167) YouTube Analytics API
+168) YouTube Reporting API
+Please enter the number corresponding to the service or 0 to exit
+> 166
+wrote /private/var/folders/km/h0s9nvsd1n58sbrn2wjsf1h80000gn/T/youtubev3.swift
 ```
 
-This can be redirected to a file for easier inspection:
+It is also possible to run the generator with Discovery Documents downloaded from the Discovery Service by passing the json file as argument:
+
+Running the following creates a file named `discovery-document-filename.swift` in your current directory.
+
 ```sh
-google-api-swift-generator <discovery-document-filename> > client.swift
+google-api-swift-generator <discovery-document-filename.json>
 ```
-
 
 This project also includes an experimental CLI generator that
 generates command-line interfaces for APIs. These CLIs depend
 on the generated client libraries and are produced with the
 `google-cli-swift-generator` command. Running the following
 writes a CLI `main.swift` to standard output:
- 
+
 ```sh
-google-cli-swift-generator <discovery-document-filename>
+google-cli-swift-generator <discovery-document-filename.json>
 ```
 
 The [Examples](Examples) directory contains several example 

--- a/Sources/Discovery/Discovery.swift
+++ b/Sources/Discovery/Discovery.swift
@@ -86,6 +86,31 @@ public class AuthScope : Codable {
   public var description : String
 }
 
+public class Icon : Codable {
+  public var x16 : String
+  public var x32 : String
+}
+
+public class DirectoryItem : Codable {
+  public var kind : String
+  public var id : String
+  public var name : String
+  public var version : String
+  public var title : String
+  public var description : String
+  public var discoveryRestUrl : URL
+  public var icons : Icon
+  public var documentationLink : String
+  public var labels : [String]?
+  public var preferred : Bool
+}
+
+public class DirectoryList : Codable {
+  public var kind : String
+  public var discoveryVersion : String
+  public var items : [DirectoryItem]
+}
+
 public class Schema : Codable {
   public var id : String?
   public var type : String?


### PR DESCRIPTION
After this pull request, running `google-api-swift-generator` will list all available Google APIs and generate a Swift client file in your current directory.

```sh
./google-api-swift-generator
  1) Abusive Experience Report API
  2) Accelerated Mobile Pages (AMP) URL API
  3) Access Approval API
  4) Access Context Manager API
  5) Ad Exchange Buyer API
  6) Ad Exchange Buyer API II
  7) Ad Experience Report API
  8) Admin Reports API
  9) AdSense Management API
 10) AdSense Host API
 11) G Suite Alert Center API
 12) Google Analytics API
[...]
165) Web Security Scanner API
166) YouTube Data API
167) YouTube Analytics API
168) YouTube Reporting API
Please enter the number corresponding to the service or 0 to exit
> 166
wrote /private/var/folders/km/h0s9nvsd1n58sbrn2wjsf1h80000gn/T/youtubev3.swift
```