### PR TITLE
Make optional DirectoryItem.documentationLink

### DIFF
--- a/Sources/Discovery/Discovery.swift
+++ b/Sources/Discovery/Discovery.swift
@@ -122,7 +122,7 @@ public class DirectoryItem : Codable {
   public var description : String
   public var discoveryRestUrl : URL
   public var icons : Icon
-  public var documentationLink : String
+  public var documentationLink : String?
   public var labels : [String]?
   public var preferred : Bool
 }


### PR DESCRIPTION
Fix an issue that `google-api-swift-generator` command occurs the following error.

> ERROR: keyNotFound(CodingKeys(stringValue: "documentationLink", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "items", intValue: nil), _JSONKey(stringValue: "Index 258", intValue: 258)], debugDescription: "No value associated with key CodingKeys(stringValue: \"documentationLink\", intValue: nil) (\"documentationLink\").", underlyingError: nil))

According to https://www.googleapis.com/discovery/v1/apis , it is sure that the element at 258 in `items` doesn't have `documentationLink` such below

![Screen Shot 2020-08-25 at 20 10 08](https://user-images.githubusercontent.com/1532891/91167591-2c2e9f00-e70f-11ea-8221-605d52c8f742.png)